### PR TITLE
Resync decoder on large timestamp gaps

### DIFF
--- a/src/atsc/decoder.cc
+++ b/src/atsc/decoder.cc
@@ -1045,12 +1045,14 @@ public:
     const int64_t diff = timestamp_difference( expected_inner_timestamp_,
                                                field.presentation_time_stamp );
 
-    /* field's moment has passed -> ignore (or bomb out) */
+    /* gap is too big -> bomb out and force reinitialization */
+    if ( abs( diff ) > frame_interval_ * 60 * 60 ) {
+      throw HugeTimestampDifference( "huge video timestamp difference" );
+    }
+
+    /* field's moment has passed -> ignore */
     if ( diff > 0 ) {
       cerr << "Warning, ignoring field whose timestamp has already passed (diff = " << diff / double( frame_interval_ ) << " frames).\n";
-      if ( diff > frame_interval_ * 60 * 60 ) {
-        throw HugeTimestampDifference( "huge video timestamp difference" );
-      }
       return;
     }
 
@@ -1228,12 +1230,14 @@ public:
     const int64_t diff = timestamp_difference( expected_inner_timestamp_,
                                                audio_block.presentation_time_stamp );
 
-    /* block's moment has passed -> ignore (or bomb out) */
+    /* gap is too big -> bomb out and force reinitialization */
+    if ( abs( diff ) > audio_block_duration * 187 * 60 ) {
+      throw HugeTimestampDifference( "huge audio timestamp difference" );
+    }
+
+    /* block's moment has passed -> ignore */
     if ( diff > 0 ) {
       cerr << "Warning, ignoring audio whose timestamp has already passed (diff = " << diff / double( audio_block_duration ) << " blocks).\n";
-      if ( diff > audio_block_duration * 187 * 60 ) {
-        throw HugeTimestampDifference( "huge audio timestamp difference" );
-      }
       return;
     }
 

--- a/src/atsc/decoder.cc
+++ b/src/atsc/decoder.cc
@@ -68,10 +68,7 @@ inline T * notnull( const string & context, T * const x )
 
 int64_t timestamp_difference( const uint64_t ts_64, const uint64_t ts_33 )
 {
-  const uint64_t ts_33_unwrapped = 300 *
-    (((ts_64 / 300) & 0xfffffffe00000000) | ((ts_33 / 300) & 0x1ffffffff));
-
-  return static_cast<int64_t>(ts_64) - static_cast<int64_t>(ts_33_unwrapped);
+  return static_cast<int64_t>(ts_64) - static_cast<int64_t>(ts_33);
 }
 
 struct Raster

--- a/src/atsc/decoder.cc
+++ b/src/atsc/decoder.cc
@@ -1374,6 +1374,10 @@ int main( int argc, char *argv[] )
       while ( not decoded_fields.empty() ) {
         /* initialize audio and video outputs with earliest video field as first timestamp */
         if ( not outputs_initialized ) {
+          if ( decoded_fields.front().top_field != y4m_writer.next_field_is_top() ) {
+            decoded_fields.pop();
+            continue;
+          }
           video_output.emplace( params, decoded_fields.front().presentation_time_stamp );
           audio_output.emplace( decoded_fields.front().presentation_time_stamp );
           outputs_initialized = true;

--- a/src/atsc/decoder.cc
+++ b/src/atsc/decoder.cc
@@ -1065,18 +1065,20 @@ public:
                                     field.presentation_time_stamp ) / double( frame_interval_ ) << " frames)\n";
 
       /* first field */
-      missing_field_.presentation_time_stamp = expected_inner_timestamp_;
-      missing_field_.top_field = writer.next_field_is_top();
-      write_single_field( missing_field_, writer );
-
+      write_filler_field( writer );
       /* second field */
-      missing_field_.presentation_time_stamp = expected_inner_timestamp_;
-      missing_field_.top_field = writer.next_field_is_top();
-      write_single_field( missing_field_, writer );
+      write_filler_field( writer );
     }
 
     /* write the originally requested field */
     write_single_field( field, writer );
+  }
+
+  void write_filler_field( Y4M_Writer & writer )
+  {
+    missing_field_.presentation_time_stamp = expected_inner_timestamp_;
+    missing_field_.top_field = writer.next_field_is_top();
+    write_single_field( missing_field_, writer );
   }
 };
 
@@ -1248,11 +1250,16 @@ public:
       cerr << "Generating silent blocks to fill in gap (diff now "
            << timestamp_difference( expected_inner_timestamp_,
                                     audio_block.presentation_time_stamp ) / double( audio_block_duration ) << " blocks)\n";
-      silence_.presentation_time_stamp = expected_inner_timestamp_;
-      write_block( silence_, writer );
+      write_silence( writer );
     }
 
     write_block( audio_block, writer );
+  }
+
+  void write_silence( WavWriter & writer )
+  {
+    silence_.presentation_time_stamp = expected_inner_timestamp_;
+    write_block( silence_, writer );
   }
 };
 

--- a/src/atsc/decoder.cc
+++ b/src/atsc/decoder.cc
@@ -44,13 +44,6 @@ static const unsigned int audio_block_duration = 144000;
 /* units -v '(256 / (48 kHz)) * (27 megahertz)' -> 144000 */
 static const unsigned int audio_samples_per_block = 256;
 
-/* max gap between two PES packet timestamps */
-static const unsigned int PES_timestamp_max_gap = 90000 * 60;  // 1 minute
-static const int64_t max_PES_timestamp = 0x1FFFFFFFF;  // 2^33
-
-static int64_t PES_timestamp_offset = 0;
-static int64_t last_PES_timestamp = -1;
-
 /* if tmp_dir is not empty, output to tmp_dir first and move output chunks
  * to video_output_dir or audio_output_dir */
 static string tmp_dir = "";
@@ -73,9 +66,12 @@ inline T * notnull( const string & context, T * const x )
   return x ? x : throw runtime_error( context + ": returned null pointer" );
 }
 
-int64_t timestamp_difference( const uint64_t ts1, const uint64_t ts2 )
+int64_t timestamp_difference( const uint64_t ts_64, const uint64_t ts_33 )
 {
-  return static_cast<int64_t>( ts1 ) - static_cast<int64_t>( ts2 );
+  const uint64_t ts_33_unwrapped = 300 *
+    (((ts_64 / 300) & 0xfffffffe00000000) | ((ts_33 / 300) & 0x1ffffffff));
+
+  return static_cast<int64_t>(ts_64) - static_cast<int64_t>(ts_33_unwrapped);
 }
 
 struct Raster
@@ -847,33 +843,7 @@ public:
       if ( not PES_packet_.empty() ) {
         PESPacketHeader pes_header { PES_packet_, is_video_ };
 
-        /* adjust PES presentation timestamp */
-        int64_t curr_PES_timestamp = pes_header.presentation_time_stamp;
-
-        if ( last_PES_timestamp != -1 ) {
-          int64_t diff = curr_PES_timestamp - last_PES_timestamp;
-          if ( abs( diff ) > PES_timestamp_max_gap ) {
-            if ( diff + max_PES_timestamp <= PES_timestamp_max_gap ) {
-              /* check if huge difference is caused by rollover */
-              cerr << "PES timestamp rollover detected: "
-                   << "last timestamp = " << last_PES_timestamp
-                   << ", current timestamp = " << curr_PES_timestamp << endl;
-              PES_timestamp_offset += max_PES_timestamp;
-            } else {
-              /* discontinuity detected */
-              cerr << "PES timestamp discontinuity detected: "
-                   << "last timestamp = " << last_PES_timestamp
-                   << ", current timestamp = " << curr_PES_timestamp << endl;
-              /* TODO: recover from discontinuity */
-              throw runtime_error( "PES timestamp discontinuity detected" );
-            }
-          }
-        }
-
-        last_PES_timestamp = curr_PES_timestamp;
-        int64_t adjusted_timestamp = curr_PES_timestamp + PES_timestamp_offset;
-
-        PES_packets.emplace( adjusted_timestamp,
+        PES_packets.emplace( pes_header.presentation_time_stamp,
                              pes_header.payload_start,
                              pes_header.PES_packet_length,
                              move( PES_packet_ ) );

--- a/src/atsc/decoder.cc
+++ b/src/atsc/decoder.cc
@@ -45,7 +45,7 @@ static const unsigned int audio_block_duration = 144000;
 static const unsigned int audio_samples_per_block = 256;
 
 /* max gap between two PES packet timestamps */
-static const unsigned int PES_timestamp_max_gap = 90000 * 60 * 10;  // 10 min
+static const unsigned int PES_timestamp_max_gap = 90000 * 60;  // 1 minute
 static const int64_t max_PES_timestamp = 0x1FFFFFFFF;  // 2^33
 
 static int64_t PES_timestamp_offset = 0;
@@ -854,19 +854,18 @@ public:
           int64_t diff = curr_PES_timestamp - last_PES_timestamp;
           if ( abs( diff ) > PES_timestamp_max_gap ) {
             if ( diff + max_PES_timestamp <= PES_timestamp_max_gap ) {
-              /* check if the huge difference is caused by rollover */
+              /* check if huge difference is caused by rollover */
               cerr << "PES timestamp rollover detected: "
                    << "last timestamp = " << last_PES_timestamp
                    << ", current timestamp = " << curr_PES_timestamp << endl;
               PES_timestamp_offset += max_PES_timestamp;
             } else {
               /* discontinuity detected */
-              cerr << "Warning: PES timestamp discontinuity detected: "
+              cerr << "PES timestamp discontinuity detected: "
                    << "last timestamp = " << last_PES_timestamp
                    << ", current timestamp = " << curr_PES_timestamp << endl;
-              /* TODO: recover from discontinuity; ignore for now */
-              PES_packet_.clear();
-              return;
+              /* TODO: recover from discontinuity */
+              throw runtime_error( "PES timestamp discontinuity detected" );
             }
           }
         }


### PR DESCRIPTION
Handles the "nbc-wrong-order.ts" and "nbc-correct-order.ts" test files. Has an internal consistency check to make sure a/v sync remains within +/- 20 ms.

I **hope** the 20 ms threshold is not too strict but not 100% positive -- the combination of the 5 ms audio block size and the practice of always inserting 2 fields to catch up on video might somehow prove unlucky. Let's test it in production for a while and see...