### PR TITLE
Add a wrapper and an abr algorithm trained using A2C

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,7 @@
 	path = third_party/pensieve
 	url = https://github.com/StanfordSNR/pensieve.git
 	ignore = dirty
+[submodule "third_party/abr_rl_test"]
+	path = third_party/abr_rl_test
+	url = https://github.com/sagar-pa/abr_rl_test.git
+	ignore = dirty

--- a/src/abr/python_ipc.cc
+++ b/src/abr/python_ipc.cc
@@ -1,0 +1,152 @@
+#include "python_ipc.hh"
+#include "ws_client.hh"
+#include "pid.hh"
+#include "system_runner.hh"
+#include "serialization.hh"
+#include "ipc_socket.hh"
+#include "json.hpp"
+#include <tuple>
+#include <vector>
+
+using namespace std;
+using json = nlohmann::json;
+
+bool compare_vformats(const VideoFormat & l, const VideoFormat & r)
+{
+  // lower resolution and higher crf (lower quality)
+  return make_tuple(l.width, l.height, -l.crf) < make_tuple(r.width, r.height, -r.crf);
+}
+
+PythonIPC::PythonIPC(const WebSocketClient & client,
+                   const string & abr_name, const YAML::Node & abr_config)
+  : ABRAlgo(client, abr_name)
+{
+  /* setup IPC connection */
+  string ipc_dir = "python_ipc";
+  fs::create_directory(ipc_dir);
+  ipc_file_ = fs::path(ipc_dir) /
+              (abr_name + "_"+ to_string(pid()) + "_" + to_string(client.connection_id()));
+
+  IPCSocket sock;
+  sock.set_reuseaddr();
+  sock.bind(ipc_file_);
+  sock.listen();
+
+  /* initialize past chunk information */
+  past_chunk_info_["delay"] = 0.;
+  past_chunk_info_["ssim"] = 0.;
+  past_chunk_info_["size"] = 0.;
+  past_chunk_info_["cwnd"] = 0.;
+  past_chunk_info_["in_flight"] = 0.;
+  past_chunk_info_["min_rtt"] = 0.;
+  past_chunk_info_["rtt"] = 0.;
+  past_chunk_info_["delivery_rate"] = 0.;
+
+  /* parse args for env process */
+  fs::path ipc_path = fs::current_path() / ipc_file_;
+  string test_path;
+  string model_path;
+
+  if (abr_config["test_path"] && abr_config["model_path"]) {
+    test_path = abr_config["test_path"].as<string>();
+    model_path = abr_config["model_path"].as<string>();
+  } else {
+    cerr << "PythonIPC requires specifying test file and model path in abr_config" << endl;
+    throw runtime_error("PythonIPC config missing");
+  }
+
+  /* start abr env process */
+  vector<string> prog_args {test_path, abr_name, model_path, ipc_path};
+
+  python_proc_ = make_unique<ChildProcess>(test_path,
+    [&test_path, &prog_args]() {
+      return ezexec(test_path, prog_args);
+    }
+  );
+
+  connection_ =  make_unique<FileDescriptor>(sock.accept());
+}
+
+PythonIPC::~PythonIPC()
+{
+  if (not fs::remove(ipc_file_)) {
+    cerr << "Warning: file " << ipc_file_ << " cannot be removed" << endl;
+  }
+}
+
+void PythonIPC::video_chunk_acked(Chunk && c)
+{
+  /* convert every unit of time to seconds
+    and every unit of size to Mb */
+  past_chunk_info_["delay"] = c.trans_time * 1e-3;            /* ms -> s */
+  past_chunk_info_["ssim"] = c.ssim;                          /* unitless */
+  past_chunk_info_["size"] = c.size * 1e-6;                   /* b -> Mb */
+  past_chunk_info_["cwnd"] = c.cwnd;                          /* packets */
+  past_chunk_info_["in_flight"] = c.in_flight;                /* packets */
+  past_chunk_info_["min_rtt"] = c.min_rtt * 1e-6;             /* μs -> s */
+  past_chunk_info_["rtt"] = c.rtt * 1e-6;                     /* μs -> s */
+  past_chunk_info_["delivery_rate"] = c.delivery_rate * 1e-6; /* b/s -> Mb/s */
+}
+
+VideoFormat PythonIPC::select_video_format()
+{
+  const auto & channel = client_.channel();
+  const unsigned int vduration = channel->vduration();
+  const uint64_t next_ts = client_.next_vts().value();
+  auto vformats = channel->vformats();
+  size_t num_formats = vformats.size();
+
+  assert(num_formats == ACTION_SPACE_N); // all the controllers expect the same action space
+  sort(vformats.begin(), vformats.end(), &compare_vformats); // sort by increasing quality
+
+  /* get future chunk sizes and ssims */
+  vector<vector<double>> chunk_sizes(
+    MAX_LOOKAHEAD_HORIZON, vector<double>(ACTION_SPACE_N, DEFAULT_CHUNK_SIZE));
+  vector<vector<double>> chunk_ssims(
+    MAX_LOOKAHEAD_HORIZON, vector<double>(ACTION_SPACE_N, DEFAULT_SSIM));
+
+  size_t lookahead_horizon = min(
+    MAX_LOOKAHEAD_HORIZON,
+    (channel->vready_frontier().value() - next_ts) / vduration + 1);
+
+  for (size_t i = 0; i < lookahead_horizon; i++) {
+    const auto & data_map = channel->vdata(next_ts + vduration * i);
+
+    for (size_t j = 0; j < num_formats; j++) {
+
+      try {
+        chunk_ssims[i][j] = channel->vssim(vformats[j], next_ts + vduration * i);
+      } catch (const exception & e) {
+        cerr << "Error occured when getting the ssim of "
+             << next_ts + vduration * i << " " << vformats[j] << endl;
+      }
+
+      try {
+        chunk_sizes[i][j] = get<1>(data_map.at(vformats[j])) * 1e-6; /* b -> Mb */
+      } catch (const exception & e) {
+        cerr << "Error occured when getting the size of "
+             << next_ts + vduration * i << " " << vformats[j] << endl;
+      }
+    }
+  }
+
+  /* format json to send */
+  json j;
+  j["past_chunk"] = past_chunk_info_;
+  j["buffer"] = client_.video_playback_buf(); // s
+  j["cum_rebuf"] = client_.cum_rebuffer(); // s
+  j["sizes"] = chunk_sizes; // Mb
+  j["ssims"] = chunk_ssims; // unitless
+  j["channel_name"] = channel->name(); // eg. fox, abc
+  uint16_t json_len = j.dump().length();
+
+  connection_->write(put_field(json_len) + j.dump());
+
+  /* read action received from ipc */
+  auto read_data = connection_->read_exactly(2); // read 2 byte length
+  auto rcvd_json_len = get_uint16(read_data.data());
+  auto read_json = connection_->read_exactly(rcvd_json_len);
+  size_t action = json::parse(read_json).at("action");
+
+  return vformats[action];
+}

--- a/src/abr/python_ipc.hh
+++ b/src/abr/python_ipc.hh
@@ -1,0 +1,31 @@
+#ifndef PYTHON_IPC_HH
+#define PYTHON_IPC_HH
+
+#include "abr_algo.hh"
+#include "child_process.hh"
+#include "filesystem.hh"
+#include <map>
+
+static const double DEFAULT_SSIM = 0.85; // unitless, about 8 SSIM dB
+static const double DEFAULT_CHUNK_SIZE = 3.0; // Mb
+static const size_t MAX_LOOKAHEAD_HORIZON = 5;
+static const size_t ACTION_SPACE_N = 10;
+
+class PythonIPC : public ABRAlgo
+{
+public:
+  PythonIPC(const WebSocketClient & client,
+           const std::string & abr_name, const YAML::Node & abr_config);
+  ~PythonIPC();
+
+  void video_chunk_acked(Chunk && c) override;
+  VideoFormat select_video_format() override;
+
+private:
+  std::map<std::string, double> past_chunk_info_ {};
+  fs::path ipc_file_ {};
+  std::unique_ptr<FileDescriptor> connection_ {nullptr};
+  std::unique_ptr<ChildProcess> python_proc_ {nullptr};
+};
+
+#endif /* PYTHON_IPC_HH */

--- a/src/media-server/Makefile.am
+++ b/src/media-server/Makefile.am
@@ -20,6 +20,7 @@ ws_media_server_SOURCES = ws_media_server.cc \
 	../abr/puffer_raw.hh ../abr/puffer_raw.cc \
 	../abr/puffer_ttp.cc ../abr/puffer_ttp.hh \
 	../abr/bola_basic.cc ../abr/bola_basic.hh \
+	../abr/python_ipc.hh ../abr/python_ipc.cc \
 	../../third_party/json.upstream/single_include/nlohmann/json.hpp
 ws_media_server_LDFLAGS = -L../../third_party/libtorch/lib \
 	'-Wl,-rpath,$$ORIGIN/../../third_party/libtorch/lib'

--- a/src/media-server/ws_client.cc
+++ b/src/media-server/ws_client.cc
@@ -6,6 +6,7 @@
 #include "puffer_raw.hh"
 #include "puffer_ttp.hh"
 #include "bola_basic.hh"
+#include "python_ipc.hh"
 #include "timestamp.hh"
 #include "exception.hh"
 
@@ -224,6 +225,8 @@ void WebSocketClient::init_abr_algo()
     abr_algo_ = make_unique<BolaBasic>(*this, abr_name_);
   } else if (abr_name_ == "bola_basic_v2") {
     abr_algo_ = make_unique<BolaBasic>(*this, abr_name_);
+  } else if (abr_name_ == "tara") {
+    abr_algo_ = make_unique<PythonIPC>(*this, abr_name_, abr_config_);
   } else {
     throw runtime_error("undefined ABR algorithm");
   }


### PR DESCRIPTION
The wrapper in C++ simply creates a sub-process to which it passes back-and-forth the information about the last chunk and the corresponding best action to take. All of the code is similar to Pensieve, but includes more features from Puffer, is trained using a different strategy, and is implemented using PyTorch.

Notes for using the code:

Adding the abr algorithm in settings.yml:
```yaml
abr: tara
abr_config:
  test_path: /path/to/third_party/abr_rl_test/test.py
  model_path: /path/to/third_party/abr_rl_test/models/tara_model.pt
cc: bbr
```

Virtual Environment setup:
Although there is no setup.py, to run the code, create a python environment with python >= 3.7, install torch >= 1.8.1, and edit the shebang in third_party/abr_rl_test/test.py to point to the environment created.

EDIT:
For heart's content, I've gone ahead and edited the environment variables by default in the python code using `os`. PyTorch should only execute with 1 thread per viewer.