### PR TITLE
add submodule for maguro and unagi

### DIFF
--- a/src/media-server/ws_client.cc
+++ b/src/media-server/ws_client.cc
@@ -227,6 +227,10 @@ void WebSocketClient::init_abr_algo()
     abr_algo_ = make_unique<BolaBasic>(*this, abr_name_);
   } else if (abr_name_ == "tara") {
     abr_algo_ = make_unique<PythonIPC>(*this, abr_name_, abr_config_);
+  } else if (abr_name_ == "maguro") {
+    abr_algo_ = make_unique<PythonIPC>(*this, abr_name_, abr_config_);
+  } else if (abr_name_ == "unagi") {
+    abr_algo_ = make_unique<PythonIPC>(*this, abr_name_, abr_config_);
   } else {
     throw runtime_error("undefined ABR algorithm");
   }


### PR DESCRIPTION
Two new controllers to replace tara on puffer. They are both also trained with A2C but use a different neural network than before.

Adding the abr algorithm in settings.yml:
```yaml
abr: maguro
abr_config:
  test_path: third_party/abr_rl_test/test.py
  model_path: third_party/abr_rl_test/models/maguro_model.pt
cc: bbr

abr: unagi
abr_config:
  test_path: third_party/abr_rl_test/test.py
  model_path: third_party/abr_rl_test/models/unagi_model.pt
cc: bbr
```